### PR TITLE
Create codigo de conducta

### DIFF
--- a/codigo de conducta
+++ b/codigo de conducta
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at ajpd1985@gmail.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/


### PR DESCRIPTION

+
+ ## Nuestro compromiso
+
+ Con el interés de fomentar un ambiente abierto y acogedor, como contribuyentes y mantenedores nos comprometemos a hacer que la participación en nuestro proyecto y nuestra comunidad sea una experiencia libre de acoso para todos, independientemente de su edad, tamaño corporal, discapacidad, etnia, identidad de género y expresión , nivel de experiencia, nacionalidad, apariencia personal, raza, religión o identidad y orientación sexual.
+
+ ## Nuestros estándares
+
+ Los ejemplos de comportamiento que contribuyen a crear un ambiente positivo incluyen:
+
+ * Uso de un lenguaje acogedor e inclusivo
+ * Ser respetuoso de los diferentes puntos de vista y experiencias
+ * Aceptando con gracia la crítica constructiva
+ * Centrándose en lo que es mejor para la comunidad
+ * Muestra empatía hacia otros miembros de la comunidad
+
+ Los ejemplos de comportamiento inaceptable de los participantes incluyen:
+
+ * El uso de lenguaje o imágenes sexualizadas y la atención o avances sexuales no deseados
+ * Trolling, comentarios insultantes / despectivos, y ataques personales o políticos
+ * Acoso público o privado
+ * Publicar información privada de otros, como una dirección física o electrónica, sin permiso explícito
+ * Otra conducta que razonablemente podría considerarse inapropiada en un entorno profesional
+
+ ## Nuestras responsabilidades
+
+ Los mantenedores de proyectos son responsables de aclarar los estándares de comportamiento aceptable y se espera que tomen medidas correctivas adecuadas y justas en respuesta a cualquier instancia de comportamiento inaceptable.
+
+ Los mantenedores de proyectos tienen el derecho y la responsabilidad de eliminar, editar o rechazar comentarios, confirmaciones, códigos, ediciones de wiki, problemas y otras contribuciones que no estén alineadas con este Código de Conducta, o de prohibir temporal o permanentemente a cualquier colaborador por otros comportamientos que ellos consideren inapropiados, amenazantes, ofensivos o dañinos.
+
+ ## Alcance
+
+ Este Código de Conducta se aplica tanto dentro de los espacios del proyecto como en los espacios públicos cuando un individuo representa el proyecto o su comunidad. Los ejemplos de representación de un proyecto o comunidad incluyen el uso de una dirección de correo electrónico oficial del proyecto, la publicación a través de una cuenta oficial de redes sociales o la actuación como representante designado en un evento en línea o fuera de línea. La representación de un proyecto puede ser definida y aclarada por los responsables del proyecto.
+
+ ## Aplicación
+
+ Se pueden reportar casos de comportamiento abusivo, acosador o de otro modo inaceptable contactando al equipo del proyecto a ajpd1985@gmail.com. El equipo del proyecto revisará e investigará todas las quejas y responderá de la manera que considere apropiada a las circunstancias. El equipo del proyecto está obligado a mantener la confidencialidad con respecto al reportero de un incidente. Se pueden publicar por separado más detalles de las políticas de ejecución específicas.
+
+ Los mantenedores de proyectos que no sigan o hagan cumplir el Código de Conducta de buena fe pueden enfrentar repercusiones temporales o permanentes según lo determinen otros miembros del liderazgo del proyecto.
+
+ ## Atribución
+
+ Este Código de Conducta se ha adaptado del [Covenant Contributor] [página de inicio], versión 1.4, disponible en [http://contributor-covenant.org/version/1/4][version]
+
+ [página de inicio]: http://contributor-covenant.org
+ [versión]: http://contributor-covenant.org/version/1/4/
